### PR TITLE
fix(left-side-menu.jinja): Set main doc link for blogs flavor

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-blogs/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-blogs/left-side-menu.jinja
@@ -1,3 +1,3 @@
 {%
-set main_doc_link = ("ROCm Documentation Home", projects['rocm'])
+set main_doc_link = ("ROCm Blogs", "https://rocm.blogs.amd.com/")
 %}


### PR DESCRIPTION
https://github.com/ROCm/rocm-docs-core/issues/635