### PR TITLE
fix(theme.conf): Create point fix for 6.0.2

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/theme.conf
+++ b/src/rocm_docs/rocm_docs_theme/theme.conf
@@ -10,5 +10,5 @@ flavor = rocm
 
 link_main_doc = True
 
-header_latest_version = 6.1.0
-header_release_candidate_version = 6.1.1
+header_latest_version = 6.0.2
+header_release_candidate_version = 6.1.0


### PR DESCRIPTION
Release version of rocm-docs-core with no banner and 6.0.2 and also includes additional fixes from v0.35.1