### PR TITLE
fix(layout.html): Update google-site-verification metadata

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/layout.html
+++ b/src/rocm_docs/rocm_docs_theme/layout.html
@@ -1,7 +1,7 @@
 {% extends "sphinx_book_theme/layout.html" %}
 
 {% block extrahead %}
-    <meta name="google-site-verification" content="ZOn0RZC0Pwzlmf2SaE0bRttWk1YzOhuslbpxUDchQ90" />
+    <meta name="google-site-verification" content="vo35SZt_GASsTHAEmdww7AYKPCvZyzLvOXBl8guBME4" />
 {% endblock %}
 
 {% block docs_navbar %}


### PR DESCRIPTION
For Google Search Console

Metadata content was changed during updates

RE: ROCm Users: As of March 15, 2024, [docs.amd.com](http://docs.xilinx.com/) no longer redirects to [rocm.docs.amd.com](http://rocm.docs.amd.com/). ROCm documentation can be directly referenced at [rocm.docs.amd.com](http://rocm.docs.amd.com/).