### PR TITLE
Remove major_version_zero = true from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ version = "1.0.0"
 version_files = ["pyproject.toml:^version", "docs/conf.py:^(version|release)"]
 tag_format = "v$version"
 annotated_tag = true
-major_version_zero = true
 
 [tool.isort]
 # https://github.com/timothycrosley/isort/


### PR DESCRIPTION
build(pyproject.toml): Remove major_version_zero = true (default is false) for version 1.x.x

--major-version-zero is meaningless for current version 1.0.0