### PR TITLE
fix(404.html): Remove relative link in 404.html page

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/404.html
+++ b/src/rocm_docs/rocm_docs_theme/404.html
@@ -1,5 +1,5 @@
 {%- extends "page.html" %}
 {% block body %}
 <h1>404 - Page Not Found</h1>
-<p>Return <a href="index.html">home</a> or use the sidebar navigation to get back on track.</p>
+<p>Use the navigation bar on the side to get back on track.</p>
 {% endblock %}


### PR DESCRIPTION
# Change
Remove relative link in 404.html page

# Reason
Navigation is no longer flat, so relative links will fail for some pages