### PR TITLE
fix(custom.css): add bottom margin to images in rst files

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -220,3 +220,7 @@ a#ot-sdk-btn {
 .bd-sidebar-secondary {
   z-index: 10001;
 }
+
+:not(p) img {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
This PR adds `margin-bottom: 1rem;` in custom.css to give images in rST files the same spacing as those in Markdown.

The issue is because:
1. Images generated from Markdown files are rendered as `<p><img /></p>`
2. rocm-docs Sphinx theme adds 1rem margin-bottom to \<p> tags by default.
3. Images from rST files are rendered as `<img />`.

Example of rST image before css update: https://rocm.docs.amd.com/en/latest/what-is-rocm.html

This fix should apply across all ROCm docs.