### PR TITLE
fix(projects.yaml): add rocr-runtime

### DIFF
--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -68,6 +68,9 @@ projects:
     target: https://rocm.docs.amd.com/projects/rocprofiler/en/${version}
     development_branch: amd-master
   rocrand: https://rocm.docs.amd.com/projects/rocRAND/en/${version}
+  rocr-runtime:
+    target: https://rocm.docs.amd.com/projects/ROCR-Runtime/en/${version}
+    development_branch: master
   rocsolver: https://rocm.docs.amd.com/projects/rocSOLVER/en/${version}
   rocsparse: https://rocm.docs.amd.com/projects/rocSPARSE/en/${version}
   rocthrust: https://rocm.docs.amd.com/projects/rocThrust/en/${version}


### PR DESCRIPTION
For intersphinx.
Add `external_projects_current_project` in https://github.com/ROCm/ROCR-Runtime/pull/209.