### PR TITLE
Fix the line color at dark mode

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -50,6 +50,9 @@ html[data-theme="light"] {
 /* for the dark theme */
 html[data-theme="dark"] {
   --link-color: #2899ff;
+  .line{
+    color: #fff;
+  };
 }
 
 div#site-navigation {


### PR DESCRIPTION
The list with multiple lines are not readable in dark mode.

Before:
<img width="716" alt="image" src="https://github.com/ROCm/rocm-docs-core/assets/11085043/83edcdc0-7fb1-4847-a815-1b97f739b7e8">

After:
<img width="708" alt="image" src="https://github.com/ROCm/rocm-docs-core/assets/11085043/19664c30-041d-4fcc-9381-1d202c1b459e">
