### PR TITLE
fix(header.jinja): Make GitHub repo url for install docs point to install docs instead of ROCm home

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
@@ -17,8 +17,6 @@
 
 {% if theme_repository_url.endswith("-docs") %}
     {% set repo_url = theme_repository_url|replace("-docs", "") %}
-{% elif "rocm-install-on" in theme_repository_url %}
-    {% set repo_url = "https://github.com/ROCm/ROCm" %}
 {% else %}
     {% set repo_url = theme_repository_url %}
 {% endif %}


### PR DESCRIPTION
since install docs are now public