### PR TITLE
fix(project.yaml): rocDecode and rocAL default to develop branch now

### DIFF
--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -90,7 +90,7 @@ projects:
   radeon: https://rocm.docs.amd.com/projects/radeon/en/${version}
   rocal:
     target: https://rocm.docs.amd.com/projects/rocAL/en/${version}
-    development_branch: master
+    development_branch: develop
   rocal-github: https://github.com/ROCm/rocAL/tree/${gh_version}
   rocal-file: https://github.com/ROCm/rocAL/blob/${gh_version}
   rocalution: https://rocm.docs.amd.com/projects/rocALUTION/en/${version}
@@ -106,7 +106,7 @@ projects:
   rocdbgapi-file: https://github.com/ROCm/ROCdbgapi/blob/${gh_version}
   rocdecode:
     target: https://rocm.docs.amd.com/projects/rocDecode/en/${version}
-    development_branch: master
+    development_branch: develop
   rocdecode-github: https://github.com/ROCm/rocDecode/tree/${gh_version}
   rocdecode-file: https://github.com/ROCm/rocDecode/blob/${gh_version}
   rocfft: https://rocm.docs.amd.com/projects/rocFFT/en/${version}


### PR DESCRIPTION
I could clean up the lines, but I saw a couple other repos also point "development_branch: develop".  Let me know if you'd rather we just make them like the other projects (one-liners).

This PR should resolve the intersphinx on develop:
![image](https://github.com/user-attachments/assets/571cc443-5eec-48a2-a875-28ea95a9890b)
