### PR TITLE
ci(spellcheck): Don't fail on known words with a possessive s

### DIFF
--- a/.spellcheck.yaml
+++ b/.spellcheck.yaml
@@ -101,6 +101,9 @@ matrix:
   - pyspelling.filters.context:
       context_visible_first: true
       delimiters:
+      # Ignore possessive endings
+      - open: '(?<=\w)''s(?!\w)'
+        close: '\b'
       # Ignore text between inline back ticks
       - open: '(div style|iframe).*'
         close: '\n'


### PR DESCRIPTION
Small fix to the spellcheck, so that it doesn't mark known words that are written with a possessive s as spelling error