### PR TITLE
fix(header.jinja): Replace http with https in repo URL

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-blogs/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-blogs/header.jinja
@@ -7,6 +7,7 @@
 {%
 set repo_url = theme_repository_url|replace("-internal", "")
 %}
+{% set repo_url = repo_url|replace("http://", "https://") %}
 {%
 set nav_secondary_items = {
     "GitHub": repo_url,

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
@@ -21,6 +21,8 @@
     {% set repo_url = theme_repository_url %}
 {% endif %}
 
+{% set repo_url = repo_url|replace("http://", "https://") %}
+
 {%
 set nav_secondary_items = {
     "GitHub": repo_url,


### PR DESCRIPTION
Closes https://github.com/ROCm/rocm-docs-core/issues/964

![image](https://github.com/user-attachments/assets/7b9c6846-f0a5-4862-8129-0ca3c4b9144c)

to avoid redirects from eg: http://github.com/rocm/rocm to https://github.com/rocm/rocm