### PR TITLE
Add generic theme flavor

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/generic/footer.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/generic/footer.jinja
@@ -1,0 +1,5 @@
+{% macro license_link() -%}
+    {% if theme_license_link %}
+        <li><a href="{{ theme_license_link }}">{{ theme_license_text if theme_license_text else "" }}</a></li>
+    {% endif %}
+{%- endmacro -%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/generic/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/generic/header.jinja
@@ -1,0 +1,28 @@
+{% macro top_level_header(branch, latest_version, release_candidate_version) -%}
+    {% if theme_header_title %}
+        {% set header_title = theme_header_title %}
+    {% else %}
+        {% set header_title = project ~ " " ~ version %}
+    {% endif %}
+
+    {% if theme_header_link %}
+        {% set header_link = theme_header_link %}
+    {% else %}
+        {% set header_link = "#" %}
+    {% endif %}
+
+    <a class="klavika-font hover-opacity" href="{{ header_link }}">{{ header_title }}</a>
+{%- endmacro -%}
+
+{% macro version_list() -%}
+    {% if theme_version_list_link %}
+        <a class="header-all-versions" href="{{ theme_version_list_link }}">Version List</a>
+    {% endif %}
+{%- endmacro -%}
+
+{%
+set nav_secondary_items = theme_nav_secondary_items if theme_nav_secondary_items else {
+    "GitHub": theme_repository_url if theme_repository_url else "#",
+    "Support": (theme_repository_url + "/issues/new/choose") if theme_repository_url else "#"
+}
+%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/generic/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/generic/left-side-menu.jinja
@@ -1,0 +1,3 @@
+{%
+set main_doc_link = theme_main_doc_link if theme_main_doc_link else (project, "#")
+%}

--- a/src/rocm_docs/rocm_docs_theme/theme.conf
+++ b/src/rocm_docs/rocm_docs_theme/theme.conf
@@ -9,3 +9,11 @@ show_toc_level = 1
 flavor = rocm
 
 link_main_doc = True
+
+# Generic theme options
+header_title =
+header_link =
+version_list_link =
+nav_secondary_items =
+license_link =
+license_text =

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -117,6 +117,15 @@ def _update_theme_options(app: Sphinx) -> None:
         flavor = supported_flavors[0]
         theme_opts["flavor"] = flavor
 
+    # Set default generic theme options
+    if flavor == "generic":
+        theme_opts.setdefault("header_title", "")
+        theme_opts.setdefault("header_link", "#")
+        theme_opts.setdefault("version_list_link", None)
+        theme_opts.setdefault("nav_secondary_items", {})
+        theme_opts.setdefault("license_link", None)
+        theme_opts.setdefault("license_text", "")
+
     theme_opts.setdefault(
         "article_header_start",
         ["components/toggle-primary-sidebar.html", "breadcrumbs.html"],
@@ -181,6 +190,14 @@ def setup(app: Sphinx) -> dict[str, Any]:
 
     app.connect("html-page-context", _add_custom_context)
     app.connect("builder-inited", _update_theme_options)
+
+    # Add theme option declarations
+    app.add_config_value("header_title", "", "html")
+    app.add_config_value("header_link", "#", "html")
+    app.add_config_value("version_list_link", None, "html")
+    app.add_config_value("nav_secondary_items", {}, "html", [dict])
+    app.add_config_value("license_link", None, "html")
+    app.add_config_value("license_text", "", "html")
 
     return {
         "parallel_read_safe": True,


### PR DESCRIPTION
This PR adds an additional "generic" theme flavor that is completely customizable via `conf.py`. The motivation for this new flavor is for non-ROCm specific sites (e.g. dcgpu.docs.amd.com).