### PR TITLE
fix: add "generic" to supported_flavors list

### DIFF
--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -112,7 +112,13 @@ def _update_theme_options(app: Sphinx) -> None:
     theme_opts = get_theme_options_dict(app)
     _update_repo_opts(str(app.srcdir), theme_opts)
 
-    supported_flavors = ["rocm", "local", "rocm-docs-home", "rocm-blogs"]
+    supported_flavors = [
+        "rocm",
+        "local",
+        "rocm-docs-home",
+        "rocm-blogs",
+        "generic",
+    ]
     flavor = theme_opts.get("flavor", "rocm")
     if flavor not in supported_flavors:
         logger.error(


### PR DESCRIPTION
This PR updates `theme.py` to add `generic` to the `supported_flavors` list