### PR TITLE
feat(projects.yaml): Add tensile to intersphinx mapping

### DIFF
--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -117,4 +117,5 @@ projects:
   rpp: https://rocm.docs.amd.com/projects/rpp/en/${version}
   rtd: https://docs.readthedocs.io/en/stable/
   sphinx: https://www.sphinx-doc.org/en/master/
+  tensile: https://rocm.docs.amd.com/projects/Tensile/en/${version}
   transferbench: https://rocm.docs.amd.com/projects/TransferBench/en/${version}


### PR DESCRIPTION
>Documentation for Tensile is now available. Tensile is a library that creates benchmark-driven backend implementations for GEMMs, serving primarily as a backend component of rocBLAS. See the [Tensile documentation](https://rocm.docs.amd.com/projects/Tensile/en/docs-6.3.0/src/index.html).