### PR TITLE
fix: scale down z-axis of multiple elements to prevent covering flyout

### DIFF
--- a/src/rocm_docs/data/_doxygen/extra_stylesheet.css
+++ b/src/rocm_docs/data/_doxygen/extra_stylesheet.css
@@ -597,7 +597,7 @@ html[data-theme=dark] {
 }
 
 .doxygen-content #MSearchSelectWindow, .doxygen-content #MSearchResultsWindow {
-    z-index: 9999;
+    z-index: 1999;
 }
 
 .doxygen-content #MSearchBox.MSearchBoxActive {

--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -221,6 +221,9 @@ a#ot-sdk-btn {
 }
 
 .bd-sidebar-secondary {
+  /* Header z-index is 2000, flyout z-index is 3000.
+  Setting sidebar's z-index to be between 2000 and 3000 to hover over the header
+  without covering the flyout. */
   z-index: 2001;
 }
 

--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -221,7 +221,7 @@ a#ot-sdk-btn {
 }
 
 .bd-sidebar-secondary {
-  z-index: 10001;
+  z-index: 2000;
 }
 
 .sd-card-body.rocm-card-banner {

--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -222,8 +222,7 @@ a#ot-sdk-btn {
 
 .bd-sidebar-secondary {
   /* Header z-index is 2000, flyout z-index is 3000.
-  Setting sidebar's z-index to be between 2000 and 3000 to hover over the header
-  without covering the flyout. */
+   * Setting sidebar's z-index to be between 2000 and 3000 to hover over the header without covering the flyout. */
   z-index: 2001;
 }
 

--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -99,7 +99,7 @@ div#rdc-watermark-container {
   width: 100vw;
   top: 0;
   left: 0;
-  z-index: 10000;
+  z-index: 2000;
 }
 
 img#rdc-watermark {
@@ -110,7 +110,7 @@ img#rdc-watermark {
   transform-origin: center;
   transform: translate(-50%, -50%) rotate(-45deg);
   opacity: 10%;
-  z-index: 10000;
+  z-index: 2000;
   max-width: 100%;
   max-height: calc(100% - 200px);
   object-fit: contain;
@@ -221,7 +221,7 @@ a#ot-sdk-btn {
 }
 
 .bd-sidebar-secondary {
-  z-index: 2000;
+  z-index: 2001;
 }
 
 .sd-card-body.rocm-card-banner {

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_footer.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_footer.css
@@ -2,7 +2,7 @@ footer.rocm-footer {
   background-color: #000;
   color: #fff;
   padding: 1rem;
-  z-index: 9999;
+  z-index: 1999;
   padding-top: 0px;
   padding-bottom: 0px;
 }

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -4,7 +4,7 @@ header.common-header {
     font-size: 1rem;
     line-height: 1.5rem;
     margin-bottom: 0;
-    z-index: 10000;
+    z-index: 2000;
 }
 
 header.common-header a {
@@ -751,7 +751,7 @@ header.common-header .icon-nav .icon-item ul.dropdown-menu {
   box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.24);
   padding-bottom: 0;
   transform: translateX(40%);
-  z-index: 9999;
+  z-index: 1999;
 }
 
 header.common-header

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -4,8 +4,7 @@ header.common-header {
     font-size: 1rem;
     line-height: 1.5rem;
     margin-bottom: 0;
-    /* readthedocs flyout z-index is 3000, setting header z-index to be
-    below 3000 to avoid covering the flyout */
+    /* readthedocs flyout z-index is 3000, setting header z-index to be below 3000 to avoid covering the flyout. */
     z-index: 2000; 
 }
 

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -4,7 +4,9 @@ header.common-header {
     font-size: 1rem;
     line-height: 1.5rem;
     margin-bottom: 0;
-    z-index: 2000;
+    /* readthedocs flyout z-index is 3000, setting header z-index to be
+    below 3000 to avoid covering the flyout */
+    z-index: 2000; 
 }
 
 header.common-header a {

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -4,8 +4,8 @@ header.common-header {
     font-size: 1rem;
     line-height: 1.5rem;
     margin-bottom: 0;
-    /* readthedocs flyout z-index is 3000, setting header z-index to be below 3000 to avoid covering the flyout. */
-    z-index: 2000; 
+/* readthedocs flyout z-index is 3000, setting header z-index to be below 3000 to avoid covering the flyout. */
+    z-index: 2000;
 }
 
 header.common-header a {


### PR DESCRIPTION
The new flyout feature introduced by readthedocs has z-index set to 3000. I'm scaling down our z-index setting to prevent the flyout being covered by other elements.

![image](https://github.com/user-attachments/assets/9cea3dfe-5ec7-4420-8c0a-37bde032b168)
![image](https://github.com/user-attachments/assets/df26a5be-2311-438d-9424-ece0f6af856b)


