### PR TITLE
ci: update upload-artifacts/download-artifacts/checkout actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python
@@ -58,7 +58,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.revision || github.sha }}
     - uses: actions/setup-python@v4
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip install build==0.10.0
         python -m build
-    - uses: actions/upload-artifact@v3.1.2
+    - uses: actions/upload-artifact@v4.3.6
       with:
         name: dist-python${{ matrix.python-version }}
         path: dist
@@ -46,7 +46,7 @@ jobs:
     env:
       PYTHON_VERSION: "3.10"
     steps:
-      - uses: actions/download-artifact@v3.0.2
+      - uses: actions/download-artifact@v4.1.8
         with:
           name: dist-python${{ env.PYTHON_VERSION }}
           path: dist

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,7 +19,7 @@ jobs:
       revision: ${{ steps.cz-bump.outputs.revision }}
       sha: ${{ steps.cz-bump.outputs.sha }}
     steps:
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python


### PR DESCRIPTION
v3 actions has been deprecated, updating workflow actions to v4.
For upload-artifacts, v4.4 excludes hidden files by default, I'm not sure .devcontainer needs to be uploaded so I'm updating the version to v4.3.6