### PR TITLE
fix: add verison_list() function definition to rocm-ds flavor

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ds/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ds/header.jinja
@@ -1,8 +1,6 @@
 {% macro top_level_header(branch, latest_version, release_candidate_version) -%}
     {% if branch in ["develop", "master", "main", "amd-master", "amd-staging"] %}
         {% set version_name = "Future Release" %}
-    {% elif branch == "latest" %}
-        {% set version_name = latest_version %}
     {% else %}
         {% set version_name = branch %}
     {% endif %}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ds/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ds/header.jinja
@@ -17,6 +17,12 @@
 
 {% set repo_url = repo_url|replace("http://", "https://") %}
 
+{% macro version_list() -%}
+    {% if theme_version_list_link %}
+        <a class="header-all-versions" href="{{ theme_version_list_link }}">Version List</a>
+    {% endif %}
+{%- endmacro -%}
+
 {%
 set nav_secondary_items = {
     "GitHub": repo_url,


### PR DESCRIPTION
rocm-ds portal intends to use a different version to rocm portal, delete branch == "latest" case to prevent it from using rocm's latest version.

Added definition to verison_list() 