### PR TITLE
ci: update pypi publish action to support metadata v2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,6 @@ jobs:
         with:
           name: dist-python${{ env.PYTHON_VERSION }}
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.8.5
+      - uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Old 1.8.5 version is not compatible with metadata v2.4 as addressed: https://github.com/pypa/gh-action-pypi-publish/issues/351

This causes the following error: 
![image](https://github.com/user-attachments/assets/13576bf7-70f8-43aa-890e-95966b473de6)

Update pypa/gh-action-pypi-publish to the newest version to fix it.