### PR TITLE
fix: repo publication approved; revert back menu items

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ds/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ds/header.jinja
@@ -25,10 +25,13 @@
 
 {%
 set nav_secondary_items = {
+    "GitHub": repo_url,
+    "Community": "https://github.com/ROCm/ROCm/discussions",
     "Blogs": "https://rocm.blogs.amd.com/",
     "ROCm&#8482; Docs": "https://rocm.docs.amd.com",
     "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
     "Instinct&#8482; Docs": "https://instinct.docs.amd.com",
     "Infinity Hub": "https://www.amd.com/en/developer/resources/infinity-hub.html",
+    "Support": repo_url + "/issues/new/choose"
 }
 %}


### PR DESCRIPTION
These items were previously removed due to repo's visibility. Now they are public and time to put them back!