### PR TITLE
fix: add edge cases to SSH pattern matching

### DIFF
--- a/src/rocm_docs/util.py
+++ b/src/rocm_docs/util.py
@@ -55,12 +55,20 @@ def get_branch(
         return (remote_details[0], remote_details[1])
 
     def get_repo_url(remote_url: str) -> str:
-        ssh_pattern = re.compile(r"git@(\w+(?:\.\w+)+):(.*)\.git")
+        ssh_pattern = re.compile(r"git@(\w+(?:\.\w+)+):(.*?)(?:\.git)?$")
+        custom_ssh_pattern = re.compile(r"git@([^:]+):(.*?)(?:\.git)?$")
         http_pattern = re.compile(r"(https?://.+)\.git")
-        remote_url, num_subs = ssh_pattern.subn(
+        remote_url, ssh_num_subs = ssh_pattern.subn(
             r"http://\1/\2", remote_url, count=1
         )
-        if num_subs > 0:
+        if ssh_num_subs > 0:
+            return remote_url
+        # If ssh prefix does not follow git@xxx.xxx format,
+        # the user could be using a secondary SSH key for EMU
+        remote_url, custom_ssh_num_subs = custom_ssh_pattern.subn(
+            r"http://github.com/\2", remote_url, count=1
+        )
+        if custom_ssh_num_subs > 0:
             return remote_url
         return http_pattern.sub(r"\1", remote_url, count=1)
 


### PR DESCRIPTION
The PR modifies the code that extracts repo's url based on the local clone. The current implementation considers two cases:
- git@github.com:ROCm/ROCm.git (SSH format)
- https://github.com/ROCm/ROCm.git (HTTP format)

However, in SSH format, the ".git" suffix is optional. It is valid for users to clone using git@github.com:ROCm/ROCm and the match will fail. In addition, due to EMU repos, the user will have a secondary SSH key causing the prefix not following the "git@xxx.xxx" format. 

Modifying the existing pattern to make .git suffix optional and adding a new pattern for non github.com SSH key.