### PR TITLE
fix(llms): require a fully-qualified base URL for link rewriting

### DIFF
--- a/src/rocm_docs/llms.py
+++ b/src/rocm_docs/llms.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from html.parser import HTMLParser
 from pathlib import Path
+from urllib.parse import urlparse
 
 import sphinx.util.logging
 from docutils import nodes
@@ -569,14 +570,30 @@ def _toc_path(app: Sphinx) -> Path | None:
 
 
 def _resolve_base_url(app: Sphinx) -> str:
-    """Determine the published base URL for rewriting internal links."""
+    """Determine the published base URL for rewriting internal links.
+
+    A candidate is only used if it is a fully-qualified URL (has a scheme and a
+    network location, e.g. ``https://example.com``). A scheme-less value such as
+    ``instinct.docs.amd.com`` would otherwise be emitted verbatim, producing
+    malformed links like ``instinct.docs.amd.com/page.html``; such values are
+    skipped so links fall back to relative form instead.
+    """
     for candidate in (
         app.config.rocm_docs_llms_base_url,
         getattr(app.config, "html_baseurl", ""),
         os.environ.get("READTHEDOCS_CANONICAL_URL", ""),
     ):
-        if candidate:
+        if not candidate:
+            continue
+        parsed = urlparse(candidate)
+        if parsed.scheme and parsed.netloc:
             return candidate.rstrip("/")
+        logger.warning(
+            "llms: ignoring base URL %r because it is not a fully-qualified "
+            "URL (needs a scheme, e.g. https://); internal links will be "
+            "relative",
+            candidate,
+        )
     logger.info("llms: no base URL configured; internal links will be relative")
     return ""
 

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -342,3 +342,47 @@ def test_walk_sitemap_dedupes_across_suffix_spellings() -> None:
     # "index" (root) and "page" each appear exactly once; the "index.md"
     # self-reference is de-duplicated rather than recursing forever.
     assert docnames == ["index", "page"]
+
+
+def _base_url_app(
+    llms_base_url: str = "", html_baseurl: str = ""
+) -> unittest.mock.NonCallableMock:
+    """A minimal fake Sphinx app carrying just the base-URL config values."""
+    app = unittest.mock.NonCallableMock()
+    app.config.rocm_docs_llms_base_url = llms_base_url
+    app.config.html_baseurl = html_baseurl
+    return app
+
+
+def test_resolve_base_url_accepts_fully_qualified_url() -> None:
+    from rocm_docs.llms import _resolve_base_url
+
+    app = _base_url_app(html_baseurl="https://instinct.docs.amd.com/")
+    with unittest.mock.patch.dict("os.environ", {}, clear=True):
+        assert _resolve_base_url(app) == "https://instinct.docs.amd.com"
+
+
+def test_resolve_base_url_skips_scheme_less_value() -> None:
+    """A scheme-less html_baseurl must not become the link base.
+
+    Otherwise links render as ``instinct.docs.amd.com/page.html`` rather than a
+    proper absolute URL; falling back to relative links is correct instead.
+    """
+    from rocm_docs.llms import _resolve_base_url
+
+    app = _base_url_app(html_baseurl="instinct.docs.amd.com")
+    with unittest.mock.patch.dict("os.environ", {}, clear=True):
+        assert _resolve_base_url(app) == ""
+
+
+def test_resolve_base_url_prefers_first_valid_candidate() -> None:
+    """A scheme-less higher-priority value is skipped for a valid lower one."""
+    from rocm_docs.llms import _resolve_base_url
+
+    app = _base_url_app(html_baseurl="instinct.docs.amd.com")
+    with unittest.mock.patch.dict(
+        "os.environ",
+        {"READTHEDOCS_CANONICAL_URL": "https://example.com/docs/"},
+        clear=True,
+    ):
+        assert _resolve_base_url(app) == "https://example.com/docs"


### PR DESCRIPTION
## Motivation

_resolve_base_url accepted any truthy candidate, so a scheme-less html_baseurl such as "instinct.docs.amd.com" was emitted verbatim, producing malformed links like "instinct.docs.amd.com/page.html" in llms.txt and llms-full.txt. Validate each candidate with urlparse and use it only when it has both a scheme and a netloc; otherwise warn and fall back to relative links.

## Technical Details

- In src/rocm_docs/llms.py, _resolve_base_url now parses each candidate (rocm_docs_llms_base_url → html_baseurl → READTHEDOCS_CANONICAL_URL) with urllib.parse.urlparse and only accepts it when both scheme and netloc are present (e.g. https://example.com).
- A candidate that is present but not fully-qualified (e.g. instinct.docs.amd.com) is skipped with a logger.warning, and resolution continues to the next candidate — ultimately falling back to relative links (page.html) rather than emitting a malformed absolute link.
- No behavior change on Read the Docs: RTD sets READTHEDOCS_CANONICAL_URL to a fully-qualified https:// URL, which passes validation and continues to produce correct absolute links. The fix only affects builds where the resolved base URL lacks a scheme (typically local/non-RTD builds using a scheme-less html_baseurl default).- Added from urllib.parse import urlparse import.

## Test Plan

- Added three unit tests in tests/test_llms.py exercising _resolve_base_url directly:
  - a fully-qualified URL is accepted (and trailing slash stripped),
  - a scheme-less value is rejected, falling back to "" (relative links),
  - a scheme-less higher-priority candidate is skipped in favor of a valid lower-priority one.
- Ran the full tests/test_llms.py suite to confirm no regression (the existing absolute-URL test uses a valid https:// base and must still pass).
- End-to-end validation against a real consumer: built the system-acceptance-docs site (which has a scheme-less html_baseurl default) with this patched generator and inspected the generated llms.txt/llms-full.txt.

## Test Result

- Unit tests: 22 passed (19 existing + 3 new) in tests/test_llms.py, no regressions.
- End-to-end build succeeded and logged the new warning: llms: ignoring base URL 'instinct.docs.amd.com' because it is not a fully-qualified URL (needs a scheme, e.g. https://); internal links will be relative. Generated links changed from the malformed [AMD Instinct MI355X](instinct.docs.amd.com/gpus/mi355x.html) to the valid relative [AMD Instinct MI355X](gpus/mi355x.html).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
