### PR TITLE
fix: add ROCm.AI nav item to header flavors

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
@@ -19,6 +19,10 @@ set nav_secondary_items = {
     "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
     "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
     "Toolkits": header_rocm_toolkits,
+    "ROCm.AI": {
+        "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
+    },
 }
 %}
 

--- a/src/rocm_docs/rocm_docs_theme/flavors/hyperloom/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/hyperloom/header.jinja
@@ -15,6 +15,10 @@ set nav_secondary_items = {
     "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
     "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
     "Toolkits": header_rocm_toolkits,
+    "ROCm.AI": {
+        "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
+    },
 }
 %}
 

--- a/src/rocm_docs/rocm_docs_theme/flavors/instinct/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/instinct/header.jinja
@@ -25,6 +25,10 @@ set nav_secondary_items = {
     "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
     "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
     "Toolkits": header_rocm_toolkits,
+    "ROCm.AI": {
+        "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
+    },
 }
 %}
 

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
@@ -29,6 +29,10 @@ set nav_secondary_items = {
     "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
     "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
     "Toolkits": header_rocm_toolkits,
+    "ROCm.AI": {
+        "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
+    },
 }
 %}
 


### PR DESCRIPTION
Adds a "ROCm.AI" dropdown to the nav strip, with "AMD Skills" and "ROCm CLI" sub-links, placed after "Toolkits".

Applies to the `rocm`, `instinct`, `ai-ecosystem`, and `hyperloom` flavors (`rocm-docs-home` shares `rocm`'s header via symlink). No template/CSS changes needed — `header.html` already supports dropdown submenus when a `nav_secondary_items` value is a mapping.