### PR TITLE
fix: add rocm-ai docs flavor

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ai/footer.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ai/footer.jinja
@@ -1,0 +1,2 @@
+{% macro license_link() -%}
+{%- endmacro -%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ai/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ai/header.jinja
@@ -1,0 +1,29 @@
+{% macro top_level_header(branch, latest_version, release_candidate_version) -%}
+    <a class="klavika-font hover-opacity" href="{{ pathto(root_doc) }}">{{ project }} {{ version }}</a>
+{%- endmacro -%}
+
+{% macro version_list() -%}
+    {% if theme_version_list_link %}
+        <a class="header-all-versions hover-opacity" href="{{ theme_version_list_link }}">Version List</a>
+    {% endif %}
+{%- endmacro -%}
+
+{%
+set nav_secondary_items = {
+    "Core SDK": "https://rocm.docs.amd.com",
+    "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
+    "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
+    "Toolkits": header_rocm_toolkits,
+    "ROCm.AI": {
+        "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
+    },
+}
+%}
+
+{%
+set nav_secondary_items_end = {
+    "Blogs": "https://rocm.blogs.amd.com/",
+    "Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
+}
+%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ai/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ai/left-side-menu.jinja
@@ -1,0 +1,1 @@
+{% set main_doc_link = ("ROCm Core SDK", projects['rocm']) %}

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -210,6 +210,7 @@ def _update_theme_options(app: Sphinx) -> None:
         "rocm-llmext",
         "rocm-ft",
         "hyperloom",
+        "rocm-ai",
         "rocm-extras",
     ]
     flavor = theme_opts.get("flavor", "rocm")


### PR DESCRIPTION
Adds a new rocm-docs-core theme flavor for the ROCm.AI product family (ROCm CLI, AMD Skills, and future products), modeled on the `hyperloom` flavor.

- Header shows the project's own name/version and links back to that site's own root page (`pathto(root_doc)`).
- Nav strip matches the other flavors (same "ROCm.AI" dropdown, added in #1616).
- Left sidebar keeps a "ROCm Core SDK" link at the top, same as the `rocm` flavor.

Verified with a local Sphinx build against the branch (editable install) — no "Unsupported theme flavor" warning, header/nav/sidebar render as expected on both the index page and inner pages.
