### PR TITLE
fix: add Hyperloom link to ROCm.AI nav menu

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
@@ -21,6 +21,7 @@ set nav_secondary_items = {
     "Toolkits": header_rocm_toolkits,
     "ROCm.AI": {
         "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/",
         "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
     },
 }

--- a/src/rocm_docs/rocm_docs_theme/flavors/hyperloom/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/hyperloom/header.jinja
@@ -17,6 +17,7 @@ set nav_secondary_items = {
     "Toolkits": header_rocm_toolkits,
     "ROCm.AI": {
         "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/",
         "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
     },
 }

--- a/src/rocm_docs/rocm_docs_theme/flavors/instinct/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/instinct/header.jinja
@@ -27,6 +27,7 @@ set nav_secondary_items = {
     "Toolkits": header_rocm_toolkits,
     "ROCm.AI": {
         "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/",
         "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
     },
 }

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ai/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ai/header.jinja
@@ -16,6 +16,7 @@ set nav_secondary_items = {
     "Toolkits": header_rocm_toolkits,
     "ROCm.AI": {
         "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/",
         "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
     },
 }

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
@@ -31,6 +31,7 @@ set nav_secondary_items = {
     "Toolkits": header_rocm_toolkits,
     "ROCm.AI": {
         "AMD Skills": "https://rocm.docs.amd.com/projects/amd-skills/en/latest/",
+        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/",
         "ROCm CLI": "https://rocm.docs.amd.com/projects/rocm-cli/en/latest/",
     },
 }


### PR DESCRIPTION
## Motivation
The "ROCm.AI" dropdown (added in #1616) links to AMD Skills and ROCm CLI but is missing a link to the Hyperloom docs.

## Technical Details
Adds a "Hyperloom" entry to the `ROCm.AI` nav dropdown, alphabetically between "AMD Skills" and "ROCm CLI", across all flavors that carry the dropdown (`rocm`, `hyperloom`, `instinct`, `ai-ecosystem`, `rocm-ai`).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.