### PR TITLE
fix: bump rocm-docs-core pin to 1.40.2

### DIFF
--- a/env/sphinx/requirements.in
+++ b/env/sphinx/requirements.in
@@ -1,7 +1,7 @@
 # Unified requirements.in for all ROCm docs
 # To regenerate: pip-compile requirements.in
 
-rocm-docs-core[api_reference,llms]==1.40.1
+rocm-docs-core[api_reference,llms]==1.40.2
 
 # Required by: most projects
 sphinxcontrib-datatemplates==0.11.0

--- a/env/sphinx/requirements.txt
+++ b/env/sphinx/requirements.txt
@@ -236,7 +236,7 @@ requests==2.34.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core[api-reference,llms]==1.40.1
+rocm-docs-core[api-reference,llms]==1.40.2
     # via -r requirements.in
 rpds-py==0.30.0
     # via


### PR DESCRIPTION
## Motivation
`env/sphinx/requirements.in` on this branch still pinned `rocm-docs-core` to `1.40.1`. Downstream consumers of the legacy raw-URL lockfile mechanism (e.g. `ROCm/legacy-rocm-build`'s `docs/10.0.0` branch, via `-r https://raw.githubusercontent.com/ROCm/rocm-docs-core/new_data/env/sphinx/requirements.txt`) were therefore stuck on `1.40.1` instead of picking up the latest `1.40.2` release.

## Technical Details
- Bumped `rocm-docs-core[api_reference,llms]==1.40.1` → `==1.40.2` in `requirements.in`.
- Regenerated `requirements.txt` with `pip-compile` using Python 3.10 (matching the original lockfile's declared interpreter) to keep the diff limited to the version bump.

## Test Plan
- Diffed the regenerated lockfile against the original to confirm only the `rocm-docs-core` pin and the `pip-compile` command comment changed.

## Test Result
- `requirements.txt` now pins `rocm-docs-core[api-reference,llms]==1.40.2`, no unrelated dependency drift.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.