### PR TITLE
feat: add centralized remote_content extension

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -231,6 +231,7 @@ NUMA
 NVCC
 NVIDIA
 NVPTX
+Namespaced
 Nano
 Navi
 Noncoherently
@@ -649,6 +650,7 @@ rccl
 rdc
 reStructuredText
 reformats
+repo
 repos
 representativeness
 req

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -23,6 +23,7 @@ subtrees:
       - file: user_guide/doxygen_integration
       - file: user_guide/article_info
       - file: user_guide/llms
+      - file: user_guide/remote_content
       - file: user_guide/selector
   - caption: Developer guide
     entries:

--- a/docs/user_guide/remote_content.md
+++ b/docs/user_guide/remote_content.md
@@ -1,0 +1,105 @@
+---
+myst:
+    html_meta:
+        "description": "Include RST content from another ROCm repository at the matching branch or tag using the remote-content directive"
+        "keywords": "remote-content, remote content, cross-repo include, branch-aware, ROCm docs core user guide"
+---
+
+# Remote content
+
+Use the `remote-content` directive to pull an `.rst` file from another GitHub
+repository into the current page at build time. It selects the branch or tag of
+the source repository that matches the version being built, so a release build
+inlines release content and a development build inlines development content.
+
+Beyond inlining, the directive rewrites `:doc:` cross-references to external
+URLs (or remaps them to local pages), downloads referenced images, applies text
+and regex replacements, adds widths to CSV tables, and can fix common LaTeX math
+issues.
+
+## Enabling the extension
+
+The directive is opt-in. Add it to `extensions` in `conf.py`:
+
+```python
+extensions = [
+    "rocm_docs",
+    "rocm_docs.remote_content",
+]
+```
+
+## Basic usage
+
+```rst
+.. remote-content::
+   :repo: ROCm/ROCm
+   :path: docs/about/what-is-rocm.rst
+   :default_branch: develop
+```
+
+On a release build (a `docs-X.Y.Z` branch, or a Read the Docs tag build), the
+directive fetches `docs/about/what-is-rocm.rst` from the matching tag. Otherwise
+it falls back to `default_branch`.
+
+## Version selection
+
+The target ref is chosen as follows:
+
+- If the build is a **release** (the `version` is `X.Y.Z` and one of: the local
+  branch is a `docs/` branch, `READTHEDOCS_VERSION_TYPE` is `tag`, or the version
+  appears in the `READTHEDOCS_VERSION` slug), the ref is `<tag_prefix><version>`.
+- Otherwise the ref is `default_branch`.
+
+If a release fetch fails (for example, the tag does not exist yet), the directive
+retries once against `default_branch`.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `repo` | Source repository as `owner/name` (required). |
+| `path` | Path to the `.rst` file within the source repo (required). |
+| `default_branch` | Branch to use when the build is not a release, and as the release fallback. |
+| `tag_prefix` | Prefix prepended to the version to form the release tag (e.g. `docs-`). |
+| `start_line` | Include the file starting from this line number. |
+| `replace` | Literal text replacements, `old\|new`, multiple separated by `;;`. |
+| `replace_re` | Regex replacements, `pattern\|replacement` (DOTALL; `\n` in the replacement becomes a newline), multiple separated by `;;`. |
+| `project_name` | Override the project name used when building external `:doc:` URLs. |
+| `docs_base_url` | Override the base URL used for external `:doc:` URLs. |
+| `doc_ignore` | `:doc:` targets to leave unconverted, separated by `;;`. |
+| `doc_remap` | Remap `:doc:` targets to local pages: `old\|new` or `old\|new_text\|new`, separated by `;;`. |
+| `csv_widths` | Add a `:widths:` value (e.g. `33 67`) to CSV tables that lack one. |
+| `fix_latex_math` | Set to `true` to escape underscores inside `\text{}` in math. |
+
+### Handling `:doc:` references
+
+By default, each `:doc:` role in the fetched content is rewritten to an absolute
+URL on the published documentation site, so links resolve from the page that
+inlined the content. You can change this per target:
+
+- **`doc_ignore`** leaves a target as a normal `:doc:` role (useful when the
+  target also exists locally or is resolved by intersphinx).
+- **`doc_remap`** rewrites a target to a different **local** page. Use
+  `old|new` to keep the original link text, or `old|new_text|new` to also
+  change the displayed text.
+
+Namespaced references such as `:doc:`rocm:about/release-notes`` are left
+untouched so intersphinx can resolve them, unless a `doc_remap` entry matches.
+
+## Configuration
+
+The base URL used to build external `:doc:` links defaults to
+`https://rocm.docs.amd.com/projects`. Override it globally in `conf.py`:
+
+```python
+rocm_docs_remote_content_docs_base = "https://rocm.docs.amd.com/projects"
+```
+
+The per-directive `docs_base_url` option takes precedence over this value.
+
+## Images
+
+Images referenced by the fetched content are downloaded into
+`_remote_images/<owner>_<name>/` under the Sphinx source directory and the image
+nodes are updated to point at the local copies, so they render without depending
+on the remote host at serve time. Absolute image URLs are left unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   "sphinx_external_toc>=0.3.1",
   "sphinx-notfound-page>=0.8.3",
   "pyyaml>=6.0",
-  "fastjsonschema>=2.16"
+  "fastjsonschema>=2.16",
+  "requests>=2.28.0"
 ]
 requires-python = ">=3.10"
 

--- a/src/rocm_docs/remote_content.py
+++ b/src/rocm_docs/remote_content.py
@@ -1,0 +1,662 @@
+"""Branch-aware ``remote-content`` Sphinx directive.
+
+Downloads an ``.rst`` file from another GitHub repository at a branch or tag
+matching the current documentation build, then inlines it. Along the way it can
+rewrite ``:doc:`` roles to external URLs, remap or ignore selected doc links,
+download referenced images, apply text and regex replacements, add widths to
+CSV tables, and fix common LaTeX math issues.
+
+This is the canonical implementation, consolidated from copies that had been
+duplicated (and diverged) across ROCm documentation repositories. Enable it by
+adding ``"rocm_docs.remote_content"`` to ``extensions`` in ``conf.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import os
+import re
+from pathlib import Path
+
+import requests
+import sphinx.util.logging
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import StringList
+from sphinx.application import Sphinx
+from sphinx.util.nodes import nested_parse_with_titles
+
+logger = sphinx.util.logging.getLogger(__name__)
+
+CONFIG_DOCS_BASE = "rocm_docs_remote_content_docs_base"
+DEFAULT_DOCS_BASE = "https://rocm.docs.amd.com/projects"
+
+
+class BranchAwareRemoteContent(Directive):
+    """Include RST content from another repo at the matching branch/tag.
+
+    Usage::
+
+        .. remote-content::
+           :repo: owner/repository
+           :path: path/to/file.rst
+           :default_branch: docs/develop  # Branch to use when not on a release
+           :tag_prefix: docs/  # Optional
+           :replace: old1|new1;; old2|new2
+           :project_name: ProjectName  # Optional override for URL construction
+           :docs_base_url: https://rocm.docs.amd.com/projects  # Optional
+           :doc_ignore: path/to/ignore;; another/path
+           :doc_remap: remote/path|local/path;; remote/path2|New Text|local/path2
+
+    The ``:replace:`` option uses ``|`` to separate old and new text, and ``;;``
+    to separate multiple replacements. ``:doc_ignore:`` uses ``;;`` to separate
+    paths left unconverted. ``:doc_remap:`` remaps ``:doc:`` links to local
+    paths, in the format ``old_path|new_path`` (keeps display text) or
+    ``old_path|new_display_text|new_path``.
+    """
+
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = True
+    has_content = False
+    option_spec = {  # noqa: RUF012
+        "repo": str,
+        "path": str,
+        "default_branch": str,  # Branch to use when not on a release tag
+        "start_line": int,  # Include the file from a specific line
+        "tag_prefix": str,  # Prefix for release tags (e.g., 'docs/')
+        "replace": str,  # Text replacement "old|new" (;; separates multiple)
+        "project_name": str,  # Override project name for URL construction
+        "docs_base_url": str,  # Override base URL for documentation
+        "doc_ignore": str,  # Doc links to leave unconverted (;; separated)
+        "doc_remap": str,  # Remap doc links to local paths (;; separated)
+        "csv_widths": str,  # Add widths to CSV tables (e.g., "33 67")
+        "fix_latex_math": str,  # Enable LaTeX math fixes (true/false)
+        "replace_re": str,  # Regex replacements "pattern|replacement" (;; sep)
+    }
+
+    def get_current_version(self) -> str | None:
+        """Return the version being built if this is a release build."""
+        env = self.state.document.settings.env
+        html_context = env.config.html_context
+
+        version = html_context.get("version", "")
+        if not re.match(r"^\d+\.\d+\.\d+$", version):
+            return None
+
+        # Detect a release build in order of reliability:
+        # 1. Local: building from a docs/ branch (official_branch == 0).
+        # 2. Read the Docs tag build: READTHEDOCS_VERSION_TYPE is "tag".
+        # 3. Read the Docs tag build (fallback): the version number appears
+        #    in the READTHEDOCS_VERSION slug (e.g. "docs-7.13.0" contains
+        #    "7.13.0"). This handles environments where VERSION_TYPE is unset.
+        rtd_version_slug = os.environ.get("READTHEDOCS_VERSION", "")
+        is_release = (
+            html_context.get("official_branch") == 0
+            or os.environ.get("READTHEDOCS_VERSION_TYPE") == "tag"
+            or (bool(rtd_version_slug) and version in rtd_version_slug)
+        )
+
+        if is_release:
+            return str(version)
+        return None
+
+    def get_target_ref(self) -> str | None:
+        """Return the git ref (tag or branch) to fetch content from."""
+        current_version = self.get_current_version()
+
+        # If it's a version number, use tag prefix and version
+        if current_version:
+            tag_prefix = self.options.get("tag_prefix", "")
+            return f"{tag_prefix}{current_version}"
+
+        # For any other case, use the specified default branch
+        if "default_branch" not in self.options:
+            logger.warning(
+                "No default_branch specified and not building from a version "
+                "tag"
+            )
+            return None
+
+        return str(self.options["default_branch"])
+
+    def get_project_name(self) -> str:
+        """Return the project name used when constructing doc URLs."""
+        if "project_name" in self.options:
+            return str(self.options["project_name"])
+
+        # Parse from repo: "ROCm/HIP" -> "HIP"
+        repo = self.options.get("repo", "")
+        if "/" in repo:
+            return str(repo.split("/")[-1])
+
+        return str(repo)
+
+    def get_ignored_doc_paths(self) -> list[str]:
+        """Return the list of doc paths that should not be converted."""
+        if "doc_ignore" not in self.options:
+            return []
+
+        ignored_paths = self.options["doc_ignore"].split(";;")
+        return [path.strip() for path in ignored_paths if path.strip()]
+
+    def get_doc_remaps(self) -> list[tuple[str, str | None, str]]:
+        """Return doc path remappings as ``(old, display_or_None, new)``."""
+        if "doc_remap" not in self.options:
+            return []
+
+        remap_specs = self.options["doc_remap"].split(";;")
+
+        remaps: list[tuple[str, str | None, str]] = []
+        for raw_spec in remap_specs:
+            remap_spec = raw_spec.strip()
+            if not remap_spec:
+                continue
+
+            if "|" not in remap_spec:
+                logger.warning(
+                    'doc_remap option must be in format "old_path|new_path" '
+                    'or "old_path|new_text|new_path", got: "%s"',
+                    remap_spec,
+                )
+                continue
+
+            parts = remap_spec.split("|")
+
+            if len(parts) == 2:
+                # Format: old_path|new_path (keep original display text)
+                remaps.append((parts[0].strip(), None, parts[1].strip()))
+            elif len(parts) == 3:
+                # Format: old_path|new_display_text|new_path
+                remaps.append(
+                    (parts[0].strip(), parts[1].strip(), parts[2].strip())
+                )
+            else:
+                logger.warning(
+                    "doc_remap option has too many parts (expected 2 or 3, "
+                    'got %d): "%s"',
+                    len(parts),
+                    remap_spec,
+                )
+
+        return remaps
+
+    def get_docs_base_url(self) -> str:
+        """Return the base URL used to build external documentation links."""
+        if "docs_base_url" in self.options:
+            return str(self.options["docs_base_url"])
+
+        env = self.state.document.settings.env
+        base = getattr(env.config, CONFIG_DOCS_BASE, "")
+        if base:
+            return str(base)
+
+        return DEFAULT_DOCS_BASE
+
+    def construct_raw_url(self, repo: str, path: str, ref: str) -> str:
+        """Return the ``raw.githubusercontent.com`` URL for a repo file."""
+        return f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
+
+    def construct_doc_url(self, doc_path: str, ref: str) -> str:
+        """Return the external documentation URL for a ``:doc:`` target."""
+        base_url = self.get_docs_base_url()
+        project_name = self.get_project_name()
+
+        if doc_path.endswith(".rst"):
+            doc_path = doc_path[:-4]
+
+        # Remove leading slash to avoid double slashes in URL
+        doc_path = doc_path.lstrip("/")
+
+        # Special case: main ROCm docs don't use /projects/ structure
+        if self.options.get("repo") == "ROCm/ROCm":
+            return f"https://rocm.docs.amd.com/en/{ref}/{doc_path}.html"
+        # Standard project pattern: domain/projects/name/en/ref/path
+        return f"{base_url}/{project_name}/en/{ref}/{doc_path}.html"
+
+    def resolve_relative_doc_path(
+        self, doc_path: str, source_file_path: str
+    ) -> str:
+        """Resolve a relative ``:doc:`` target against its source file."""
+        if not doc_path.startswith("./") and not doc_path.startswith("../"):
+            return doc_path
+
+        source_dir = Path(source_file_path).parent
+        resolved_path = (source_dir / doc_path).as_posix()
+        return str(Path(resolved_path))
+
+    def process_doc_roles(self, content: str, ref: str) -> str:
+        """Convert or remap ``:doc:`` roles in the fetched content."""
+        ignored_paths = self.get_ignored_doc_paths()
+        doc_remaps = self.get_doc_remaps()
+
+        # Matches both :doc:`target` and :doc:`text <target>`.
+        doc_pattern = r":doc:`([^`]+)`"
+
+        def replace_doc_role(match: re.Match[str]) -> str:
+            full_content = match.group(1)
+
+            # Parse the display text and target ("text <target>" or "target").
+            if "<" in full_content and ">" in full_content:
+                text_match = re.match(r"(.+?)\s*<(.+?)>", full_content)
+                if text_match:
+                    display_text = text_match.group(1).strip()
+                    target = text_match.group(2).strip()
+                else:
+                    display_text = full_content
+                    target = full_content
+            else:
+                target = full_content.strip()
+                display_text = target
+
+            is_namespaced = ":" in target
+
+            # Ignore (leave unconverted) if requested.
+            if target in ignored_paths:
+                logger.info("Ignoring doc link as requested: %s", target)
+                return match.group(0)
+
+            target_stripped = target.lstrip("/")
+            if target_stripped in ignored_paths:
+                logger.info("Ignoring doc link as requested: %s", target)
+                return match.group(0)
+
+            # Remap to a local :doc: role if requested.
+            for old_path, new_display_text, new_path in doc_remaps:
+                if target == old_path or target_stripped == old_path:
+                    if new_display_text is not None:
+                        final_display_text = new_display_text
+                    else:
+                        final_display_text = display_text
+
+                    if final_display_text == new_path:
+                        result = f":doc:`{new_path}`"
+                    else:
+                        result = f":doc:`{final_display_text} <{new_path}>`"
+
+                    logger.info(
+                        "Remapped :doc:`%s` to %s", full_content, result
+                    )
+                    return result
+
+            # Leave namespaced references for intersphinx to handle.
+            if is_namespaced:
+                logger.debug(
+                    "Skipping namespaced doc reference (no remap match): %s",
+                    full_content,
+                )
+                return match.group(0)
+
+            resolved_target = self.resolve_relative_doc_path(
+                target, self.options["path"]
+            )
+            url = self.construct_doc_url(resolved_target, ref)
+            logger.info(
+                "Converted :doc:`%s` to external link: %s", full_content, url
+            )
+            return f"`{display_text} <{url}>`__"
+
+        return re.sub(doc_pattern, replace_doc_role, content)
+
+    def process_csv_tables(self, content: str) -> str:
+        """Inject ``:widths:`` into CSV tables when ``csv_widths`` is set."""
+        if "csv_widths" not in self.options:
+            return content
+
+        csv_widths = self.options["csv_widths"].strip()
+        if not csv_widths:
+            return content
+
+        # Match CSV table directives with their options (RST indentation).
+        csv_pattern = re.compile(
+            r"^(\s*)\.\. csv-table::.*?\n" r"((?:\s+:[^:]+:.*\n)*)",
+            re.MULTILINE,
+        )
+
+        def add_widths_to_csv(match: re.Match[str]) -> str:
+            indent = match.group(1)
+            existing_options = match.group(2)
+
+            if ":widths:" in existing_options:
+                return match.group(0)
+
+            header_pattern = re.compile(r"^(\s+):header:.*\n", re.MULTILINE)
+            header_match = header_pattern.search(existing_options)
+
+            if header_match:
+                option_indent = header_match.group(1)
+                widths_line = f"{option_indent}:widths: {csv_widths}\n"
+                modified_options = (
+                    existing_options[: header_match.end()]
+                    + widths_line
+                    + existing_options[header_match.end() :]
+                )
+                logger.info("Added :widths: %s to CSV table", csv_widths)
+                return f"{indent}.. csv-table::\n{modified_options}"
+            if existing_options:
+                first_option_match = re.match(r"^(\s+):", existing_options)
+                if first_option_match:
+                    option_indent = first_option_match.group(1)
+                    widths_line = f"{option_indent}:widths: {csv_widths}\n"
+                    logger.info("Added :widths: %s to CSV table", csv_widths)
+                    return (
+                        f"{indent}.. csv-table::\n"
+                        f"{widths_line}{existing_options}"
+                    )
+            else:
+                # No existing options: 3-space RST option indentation.
+                widths_line = f"   :widths: {csv_widths}\n"
+                logger.info("Added :widths: %s to CSV table", csv_widths)
+                return f"{indent}.. csv-table::\n{widths_line}"
+
+            return match.group(0)
+
+        return csv_pattern.sub(add_widths_to_csv, content)
+
+    def process_latex_math(self, content: str) -> str:
+        r"""Escape underscores inside ``\text{}`` when enabled."""
+        if "fix_latex_math" not in self.options:
+            return content
+
+        fix_latex = self.options.get("fix_latex_math", "").strip().lower()
+        if fix_latex not in ("true", "1", "yes"):
+            return content
+
+        def escape_underscores_in_text(match: re.Match[str]) -> str:
+            text_content = match.group(1)
+            escaped_content = re.sub(r"(?<!\\)_", r"\\_", text_content)
+            if escaped_content != text_content:
+                logger.info(
+                    "Fixed underscores in \\text{%s} -> \\text{%s}",
+                    text_content,
+                    escaped_content,
+                )
+            return f"\\text{{{escaped_content}}}"
+
+        # Match \text{} with one level of nested braces.
+        text_pattern = r"\\text\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}"
+        modified_content = re.sub(
+            text_pattern, escape_underscores_in_text, content
+        )
+
+        if modified_content != content:
+            logger.info("Applied LaTeX math fixes")
+
+        return modified_content
+
+    def apply_regex_replacements(self, content: str) -> str:
+        """Apply ``replace_re`` regex substitutions (multi-line aware)."""
+        if "replace_re" not in self.options:
+            return content
+
+        for raw_spec in self.options["replace_re"].split(";;"):
+            spec = raw_spec.strip()
+            if not spec:
+                continue
+            if "|" not in spec:
+                logger.warning(
+                    "replace_re option must be in format "
+                    '"pattern|replacement", got: "%s"',
+                    spec,
+                )
+                continue
+            pattern, replacement = spec.split("|", 1)
+            replacement = replacement.replace("\\n", "\n")
+            modified = re.sub(pattern, replacement, content, flags=re.DOTALL)
+            if modified != content:
+                logger.info("replace_re matched pattern: %s", pattern)
+                content = modified
+        return content
+
+    def apply_replacements(self, content: str) -> str:
+        """Apply literal ``replace`` text substitutions."""
+        if "replace" not in self.options:
+            return content
+
+        replace_specs = self.options["replace"].split(";;")
+
+        for raw_spec in replace_specs:
+            replace_spec = raw_spec.strip()
+            if not replace_spec:
+                continue
+
+            if "|" not in replace_spec:
+                logger.warning(
+                    'Replace option must be in format "old_text|new_text", '
+                    'got: "%s"',
+                    replace_spec,
+                )
+                continue
+
+            old_text, new_text = replace_spec.split("|", 1)
+            modified_content = content.replace(old_text, new_text)
+            if modified_content != content:
+                logger.info('Replaced "%s" with "%s"', old_text, new_text)
+                content = modified_content
+
+        return content
+
+    def get_image_cache_dir(self) -> Path:
+        """Return (creating if needed) the cache dir for remote images."""
+        env = self.state.document.settings.env
+        srcdir = Path(str(env.srcdir))
+        repo_dir = str(self.options["repo"]).replace("/", "_")
+        cache_dir = srcdir / "_remote_images" / repo_dir
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir
+
+    def download_image(self, image_path: str, ref: str) -> Path | None:
+        """Download a single referenced image, returning its local path."""
+        image_url = self.construct_raw_url(
+            self.options["repo"], image_path, ref
+        )
+
+        try:
+            logger.info("Downloading image from %s", image_url)
+            response = requests.get(image_url, timeout=30)
+            response.raise_for_status()
+
+            cache_dir = self.get_image_cache_dir()
+
+            # Drop a leading 'docs/' segment; we handle that separately.
+            save_path = Path(image_path)
+            if save_path.parts and save_path.parts[0] == "docs":
+                save_path = Path(*save_path.parts[1:])
+
+            local_image_path = cache_dir / save_path
+            local_image_path.parent.mkdir(parents=True, exist_ok=True)
+            local_image_path.write_bytes(response.content)
+            logger.info("Saved image to %s", local_image_path)
+            return local_image_path
+        except requests.exceptions.RequestException as error:
+            logger.warning(
+                "Failed to download image from %s: %s", image_url, error
+            )
+            return None
+
+    def _resolve_image_path(self, original_uri: str) -> str:
+        """Resolve an image URI to a repo-relative path for downloading."""
+        source_path = Path(self.options["path"])
+        source_dir = source_path.parent
+        repo = self.options.get("repo", "")
+
+        if source_dir.as_posix() and source_dir.as_posix() != ".":
+            joined_path = (source_dir / original_uri).as_posix()
+            image_path = os.path.normpath(joined_path).replace("\\", "/")
+
+            if repo == "ROCm/rocm-systems":
+                # In the rocm-systems monorepo, component docs live under
+                # projects/<component>/docs/. Derive that base from the source
+                # path so images resolve for every component, and strip any
+                # leading ../ that would escape the component directory.
+                base = ""
+                parts = source_path.as_posix().split("/")
+                if (
+                    len(parts) >= 3
+                    and parts[0] == "projects"
+                    and parts[2] == "docs"
+                ):
+                    base = f"projects/{parts[1]}/docs"
+                if base:
+                    rest_of_path = original_uri.replace("\\", "/")
+                    while rest_of_path.startswith(("../", "./")):
+                        rest_of_path = rest_of_path.split("/", 1)[1]
+                    rest_of_path = rest_of_path.lstrip("/")
+                    image_path = f"{base}/{rest_of_path}"
+            elif repo in ("ROCm/ROCm", "ROCm/rccl"):
+                if image_path.startswith("../"):
+                    image_path = f"docs/{image_path[3:]}"
+                elif not image_path.startswith("docs/"):
+                    image_path = f"docs/{image_path}"
+        else:
+            image_path = original_uri
+            if repo == "ROCm/rocm-systems" and not image_path.startswith(
+                "projects/"
+            ):
+                image_path = f"projects/hip/docs/{image_path}"
+            elif repo in (
+                "ROCm/ROCm",
+                "ROCm/rccl",
+            ) and not image_path.startswith("docs/"):
+                image_path = f"docs/{image_path}"
+
+        # Final normalization to remove any remaining ../ components.
+        image_path = os.path.normpath(image_path).replace("\\", "/")
+        return image_path.lstrip("/")
+
+    def process_image_nodes(self, node: nodes.Node, ref: str) -> None:
+        """Download images referenced in the parsed content and repoint them."""
+        srcdir = Path(str(self.state.document.settings.env.srcdir))
+        for img_node in node.findall(nodes.image):
+            original_uri = img_node.get("uri", "")
+
+            # Skip absolute URLs and source-root-absolute paths.
+            if original_uri.startswith(("http://", "https://", "/")):
+                continue
+
+            image_path = self._resolve_image_path(original_uri)
+            logger.info("Processing image: %s -> %s", original_uri, image_path)
+
+            local_image_path = self.download_image(image_path, ref)
+            if local_image_path:
+                try:
+                    rel_path = local_image_path.relative_to(srcdir)
+                    # Absolute-from-source-root path so Sphinx always finds it.
+                    new_path = "/" + str(rel_path.as_posix())
+                except ValueError:
+                    new_path = str(local_image_path.as_posix())
+
+                img_node["uri"] = new_path
+                logger.info(
+                    "Updated image URI: %s -> %s", original_uri, new_path
+                )
+            else:
+                logger.warning(
+                    "Keeping original image path due to download failure: %s",
+                    original_uri,
+                )
+
+    def fetch_and_parse_content(
+        self, url: str, source_path: str, ref: str
+    ) -> list[nodes.Node]:
+        """Fetch remote RST, apply transforms, and parse it into nodes."""
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        content = response.text
+
+        # Normalize tabs after numbered list markers to spaces.
+        content = re.sub(r"^(\s*\d+\.)\t+", r"\1 ", content, flags=re.MULTILINE)
+
+        content = self.apply_replacements(content)
+        content = self.apply_regex_replacements(content)
+        content = self.process_latex_math(content)
+        content = self.process_csv_tables(content)
+        content = self.process_doc_roles(content, ref)
+
+        start_line = self.options.get("start_line", 0)
+
+        # Compute the source path relative to Sphinx's srcdir so that
+        # directives like ``.. raw:: html :file: data/foo.html`` resolve
+        # correctly. The remote :path: includes the repo's docs/ prefix
+        # (e.g. "docs/index.rst"); locally srcdir IS the docs/ directory, so
+        # stripping that first segment gives a path whose parent matches srcdir.
+        env = self.state.document.settings.env
+        srcdir = Path(str(env.srcdir))
+        remote_path = Path(source_path)
+        try:
+            rel_source_path = str(remote_path.relative_to(remote_path.parts[0]))
+        except (ValueError, IndexError):
+            rel_source_path = source_path
+        viewlist_source = str(srcdir / rel_source_path)
+
+        content_list = StringList()
+        for line_no, line in enumerate(content.splitlines()):
+            if line_no >= start_line:
+                content_list.append(line, viewlist_source, line_no)
+
+        node = nodes.section()
+        nested_parse_with_titles(self.state, content_list, node)
+
+        # Download images after parsing and repoint their URIs.
+        self.process_image_nodes(node, ref)
+
+        return list(node.children)
+
+    def run(self) -> list[nodes.Node]:
+        """Entry point: resolve the ref, fetch, and return parsed nodes."""
+        if "repo" not in self.options or "path" not in self.options:
+            logger.warning("Both repo and path options are required")
+            return []
+
+        target_ref = self.get_target_ref()
+        logger.info(
+            "Target ref determined: %s for repo: %s",
+            target_ref,
+            self.options["repo"],
+        )
+        if not target_ref:
+            return []
+
+        raw_url = self.construct_raw_url(
+            self.options["repo"], self.options["path"], target_ref
+        )
+
+        try:
+            logger.info("Attempting to fetch content from %s", raw_url)
+            return self.fetch_and_parse_content(
+                raw_url, self.options["path"], target_ref
+            )
+        except requests.exceptions.RequestException as error:
+            logger.warning(
+                "Failed to fetch content from %s: %s", raw_url, error
+            )
+
+            # If we failed on a tag, fall back to default_branch.
+            if self.get_current_version() and "default_branch" in self.options:
+                fallback_ref = self.options["default_branch"]
+                logger.info("Attempting fallback to %s...", fallback_ref)
+                try:
+                    fallback_url = self.construct_raw_url(
+                        self.options["repo"],
+                        self.options["path"],
+                        fallback_ref,
+                    )
+                    return self.fetch_and_parse_content(
+                        fallback_url, self.options["path"], fallback_ref
+                    )
+                except requests.exceptions.RequestException as error2:
+                    logger.warning("Fallback also failed: %s", error2)
+
+            return []
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    """Set up ``rocm_docs.remote_content`` as a Sphinx extension."""
+    app.add_directive("remote-content", BranchAwareRemoteContent)
+    app.add_config_value(CONFIG_DOCS_BASE, DEFAULT_DOCS_BASE, "html", types=str)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/tests/test_remote_content.py
+++ b/tests/test_remote_content.py
@@ -1,0 +1,421 @@
+"""Tests for rocm_docs.remote_content -- the branch-aware remote-content directive.
+
+The directive's transform logic (``:doc:`` conversion, doc_ignore/doc_remap,
+replace/replace_re, CSV widths, LaTeX math, ref/version selection) is pure and
+network-free, so these tests instantiate the directive with a stub Sphinx
+environment and exercise the methods directly. The network paths
+(fetch/fallback and image download) are covered with ``requests.get`` mocked so
+they run deterministically offline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import unittest.mock
+
+import pytest
+import requests
+
+from rocm_docs.remote_content import (
+    CONFIG_DOCS_BASE,
+    DEFAULT_DOCS_BASE,
+    BranchAwareRemoteContent,
+)
+
+
+def make_directive(
+    options: dict[str, Any] | None = None,
+    *,
+    version: str = "",
+    official_branch: Any = None,
+    docs_base: str = DEFAULT_DOCS_BASE,
+    srcdir: str = "/srcdir",
+) -> BranchAwareRemoteContent:
+    """Build a directive instance with a stub env, bypassing Directive.__init__.
+
+    ``Directive.__init__`` needs the full RST state machine, which these unit
+    tests do not exercise; the transform methods only touch ``self.options`` and
+    ``self.state.document.settings.env``, so a stub env is enough.
+    """
+    directive = BranchAwareRemoteContent.__new__(BranchAwareRemoteContent)
+    directive.options = options or {}
+
+    env = unittest.mock.NonCallableMock()
+    env.config.html_context = {"version": version}
+    if official_branch is not None:
+        env.config.html_context["official_branch"] = official_branch
+    setattr(env.config, CONFIG_DOCS_BASE, docs_base)
+    env.srcdir = srcdir
+
+    state = unittest.mock.NonCallableMock()
+    state.document.settings.env = env
+    directive.state = state
+    return directive
+
+
+# --------------------------------------------------------------------------- #
+# get_current_version / get_target_ref
+# --------------------------------------------------------------------------- #
+
+
+def test_current_version_none_when_not_version_shaped() -> None:
+    d = make_directive(version="develop")
+    assert d.get_current_version() is None
+
+
+def test_current_version_release_via_official_branch() -> None:
+    d = make_directive(version="7.14.0", official_branch=0)
+    assert d.get_current_version() == "7.14.0"
+
+
+def test_current_version_release_via_rtd_version_type() -> None:
+    d = make_directive(version="7.14.0")
+    with unittest.mock.patch.dict(
+        "os.environ", {"READTHEDOCS_VERSION_TYPE": "tag"}, clear=True
+    ):
+        assert d.get_current_version() == "7.14.0"
+
+
+def test_current_version_release_via_rtd_slug() -> None:
+    d = make_directive(version="7.14.0")
+    with unittest.mock.patch.dict(
+        "os.environ", {"READTHEDOCS_VERSION": "docs-7.14.0"}, clear=True
+    ):
+        assert d.get_current_version() == "7.14.0"
+
+
+def test_current_version_none_when_not_a_release() -> None:
+    d = make_directive(version="7.14.0")
+    with unittest.mock.patch.dict("os.environ", {}, clear=True):
+        assert d.get_current_version() is None
+
+
+def test_target_ref_uses_tag_prefix_on_release() -> None:
+    d = make_directive(
+        {"tag_prefix": "docs-"}, version="7.14.0", official_branch=0
+    )
+    assert d.get_target_ref() == "docs-7.14.0"
+
+
+def test_target_ref_falls_back_to_default_branch() -> None:
+    d = make_directive({"default_branch": "docs/develop"}, version="develop")
+    assert d.get_target_ref() == "docs/develop"
+
+
+def test_target_ref_none_without_default_branch() -> None:
+    d = make_directive({}, version="develop")
+    assert d.get_target_ref() is None
+
+
+# --------------------------------------------------------------------------- #
+# project name / base URL / doc URL construction
+# --------------------------------------------------------------------------- #
+
+
+def test_project_name_from_repo() -> None:
+    assert make_directive({"repo": "ROCm/HIP"}).get_project_name() == "HIP"
+
+
+def test_project_name_explicit_override() -> None:
+    d = make_directive({"repo": "ROCm/HIP", "project_name": "Custom"})
+    assert d.get_project_name() == "Custom"
+
+
+def test_docs_base_url_uses_config_value() -> None:
+    d = make_directive(docs_base="https://example.com/projects")
+    assert d.get_docs_base_url() == "https://example.com/projects"
+
+
+def test_docs_base_url_option_overrides_config() -> None:
+    d = make_directive(
+        {"docs_base_url": "https://override.example/projects"},
+        docs_base="https://example.com/projects",
+    )
+    assert d.get_docs_base_url() == "https://override.example/projects"
+
+
+def test_construct_doc_url_project_pattern() -> None:
+    d = make_directive({"repo": "ROCm/HIP"})
+    url = d.construct_doc_url("how-to/foo.rst", "docs-7.14.0")
+    assert url == (f"{DEFAULT_DOCS_BASE}/HIP/en/docs-7.14.0/how-to/foo.html")
+
+
+def test_construct_doc_url_rocm_special_case() -> None:
+    d = make_directive({"repo": "ROCm/ROCm"})
+    url = d.construct_doc_url("about/release-notes", "docs-7.14.0")
+    assert url == (
+        "https://rocm.docs.amd.com/en/docs-7.14.0/about/release-notes.html"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# resolve_relative_doc_path
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_relative_doc_path_absolute_unchanged() -> None:
+    d = make_directive()
+    assert d.resolve_relative_doc_path("how-to/foo", "docs/index.rst") == (
+        "how-to/foo"
+    )
+
+
+def test_resolve_relative_doc_path_joins_against_source_dir() -> None:
+    d = make_directive()
+    # The path is joined against the source file's directory. `..` segments are
+    # not collapsed here (Path() does not resolve them without resolve()); that
+    # matches the canonical directive's behavior.
+    resolved = d.resolve_relative_doc_path("../ref/bar", "docs/how-to/x.rst")
+    assert resolved.replace("\\", "/") == "docs/how-to/../ref/bar"
+
+
+# --------------------------------------------------------------------------- #
+# :doc: role processing (ignore / remap / external conversion / namespaced)
+# --------------------------------------------------------------------------- #
+
+
+def test_doc_role_converted_to_external_link() -> None:
+    d = make_directive({"repo": "ROCm/HIP", "path": "docs/index.rst"})
+    out = d.process_doc_roles(":doc:`how-to/foo`", "docs-7.14.0")
+    assert f"<{DEFAULT_DOCS_BASE}/HIP/en/docs-7.14.0/how-to/foo.html>`__" in out
+
+
+def test_doc_role_with_display_text() -> None:
+    d = make_directive({"repo": "ROCm/HIP", "path": "docs/index.rst"})
+    out = d.process_doc_roles(":doc:`Foo Guide <how-to/foo>`", "docs-7.14.0")
+    assert out.startswith("`Foo Guide <")
+    assert out.endswith(">`__")
+
+
+def test_doc_role_ignored_left_unconverted() -> None:
+    d = make_directive(
+        {
+            "repo": "ROCm/HIP",
+            "path": "docs/index.rst",
+            "doc_ignore": "how-to/foo",
+        }
+    )
+    src = ":doc:`how-to/foo`"
+    assert d.process_doc_roles(src, "docs-7.14.0") == src
+
+
+def test_doc_role_remapped_to_local_keep_text() -> None:
+    d = make_directive(
+        {
+            "repo": "ROCm/HIP",
+            "path": "docs/index.rst",
+            "doc_remap": "install/guide|how-to/getting_started",
+        }
+    )
+    out = d.process_doc_roles(":doc:`install/guide`", "docs-7.14.0")
+    # Without an explicit new display text, the original target text is kept as
+    # the display text, so the remapped role uses the "text <path>" form.
+    assert out == ":doc:`install/guide <how-to/getting_started>`"
+
+
+def test_doc_role_remapped_with_new_text() -> None:
+    d = make_directive(
+        {
+            "repo": "ROCm/HIP",
+            "path": "docs/index.rst",
+            "doc_remap": "install/guide|Getting Started|how-to/getting_started",
+        }
+    )
+    out = d.process_doc_roles(":doc:`install/guide`", "docs-7.14.0")
+    assert out == ":doc:`Getting Started <how-to/getting_started>`"
+
+
+def test_doc_role_namespaced_left_for_intersphinx() -> None:
+    d = make_directive({"repo": "ROCm/HIP", "path": "docs/index.rst"})
+    src = ":doc:`rocm:about/release-notes`"
+    assert d.process_doc_roles(src, "docs-7.14.0") == src
+
+
+# --------------------------------------------------------------------------- #
+# replace / replace_re
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_replacements_multiple() -> None:
+    d = make_directive({"replace": "foo|bar;; baz|qux"})
+    assert d.apply_replacements("foo and baz") == "bar and qux"
+
+
+def test_apply_replacements_noop_without_option() -> None:
+    d = make_directive({})
+    assert d.apply_replacements("unchanged") == "unchanged"
+
+
+def test_apply_regex_replacements_with_newline_escape() -> None:
+    d = make_directive({"replace_re": r"a\s+b|A\nB"})
+    assert d.apply_regex_replacements("a   b") == "A\nB"
+
+
+def test_apply_regex_replacements_dotall_multiline() -> None:
+    d = make_directive({"replace_re": r"START.*END|GONE"})
+    assert d.apply_regex_replacements("START\nx\ny\nEND") == "GONE"
+
+
+# --------------------------------------------------------------------------- #
+# CSV widths / LaTeX math
+# --------------------------------------------------------------------------- #
+
+
+def test_csv_widths_injected_after_header() -> None:
+    d = make_directive({"csv_widths": "33 67"})
+    content = ".. csv-table::\n   :header: A, B\n\n   1, 2\n"
+    out = d.process_csv_tables(content)
+    assert ":widths: 33 67" in out
+    # widths appears after the header option.
+    assert out.index(":header:") < out.index(":widths:")
+
+
+def test_csv_widths_not_duplicated() -> None:
+    d = make_directive({"csv_widths": "33 67"})
+    content = ".. csv-table::\n   :header: A, B\n   :widths: 10 90\n"
+    out = d.process_csv_tables(content)
+    assert out.count(":widths:") == 1
+    assert ":widths: 10 90" in out
+
+
+def test_latex_math_escapes_underscores_when_enabled() -> None:
+    d = make_directive({"fix_latex_math": "true"})
+    out = d.process_latex_math(r"\text{a_b_c}")
+    assert out == r"\text{a\_b\_c}"
+
+
+def test_latex_math_noop_when_disabled() -> None:
+    d = make_directive({"fix_latex_math": "false"})
+    assert d.process_latex_math(r"\text{a_b}") == r"\text{a_b}"
+
+
+# --------------------------------------------------------------------------- #
+# image path resolution (pure helper)
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_image_path_rocm_adds_docs_prefix() -> None:
+    d = make_directive({"repo": "ROCm/ROCm", "path": "docs/how-to/x.rst"})
+    # ../data/img.png from docs/how-to/ normalizes to docs/data/img.png
+    assert d._resolve_image_path("../data/img.png") == "docs/data/img.png"
+
+
+def test_resolve_image_path_rocm_systems_component_base() -> None:
+    d = make_directive(
+        {
+            "repo": "ROCm/rocm-systems",
+            "path": "projects/hip/docs/how-to/x.rst",
+        }
+    )
+    out = d._resolve_image_path("../../data/img.png")
+    assert out == "projects/hip/docs/data/img.png"
+
+
+# --------------------------------------------------------------------------- #
+# network paths (mocked)
+# --------------------------------------------------------------------------- #
+
+
+def _mock_response(text: str = "", status_ok: bool = True) -> Any:
+    resp = unittest.mock.NonCallableMock()
+    resp.text = text
+    resp.content = text.encode()
+    if status_ok:
+        resp.raise_for_status.return_value = None
+    else:
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+    return resp
+
+
+def test_run_fetches_and_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    d = make_directive(
+        {"repo": "ROCm/HIP", "path": "docs/index.rst"},
+        version="7.14.0",
+        official_branch=0,
+    )
+    captured: dict[str, str] = {}
+
+    def fake_fetch(url: str, _source_path: str, ref: str) -> list[Any]:
+        captured["url"] = url
+        captured["ref"] = ref
+        return ["PARSED"]
+
+    monkeypatch.setattr(d, "fetch_and_parse_content", fake_fetch)
+    result: list[Any] = d.run()
+    assert result == ["PARSED"]
+    assert captured["ref"] == "7.14.0"
+    assert captured["url"] == (
+        "https://raw.githubusercontent.com/ROCm/HIP/7.14.0/docs/index.rst"
+    )
+
+
+def test_run_falls_back_to_default_branch_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    d = make_directive(
+        {
+            "repo": "ROCm/HIP",
+            "path": "docs/index.rst",
+            "default_branch": "docs/develop",
+        },
+        version="7.14.0",
+        official_branch=0,
+    )
+    calls: list[str] = []
+
+    def fake_fetch(_url: str, _source_path: str, ref: str) -> list[Any]:
+        calls.append(ref)
+        if ref == "7.14.0":
+            raise requests.exceptions.ConnectionError("boom")
+        return ["FALLBACK"]
+
+    monkeypatch.setattr(d, "fetch_and_parse_content", fake_fetch)
+    result: list[Any] = d.run()
+    assert result == ["FALLBACK"]
+    # First the tag, then the fallback branch.
+    assert calls == ["7.14.0", "docs/develop"]
+
+
+def test_run_returns_empty_without_repo_or_path() -> None:
+    assert make_directive({"repo": "ROCm/HIP"}).run() == []
+    assert make_directive({"path": "docs/index.rst"}).run() == []
+
+
+def test_download_image_writes_file(tmp_path: Any) -> None:
+    d = make_directive(
+        {"repo": "ROCm/HIP", "path": "docs/index.rst"},
+        srcdir=str(tmp_path),
+    )
+    with unittest.mock.patch(
+        "requests.get", return_value=_mock_response("PNGDATA")
+    ):
+        local = d.download_image("docs/data/img.png", "7.14.0")
+    assert local is not None
+    assert local.read_bytes() == b"PNGDATA"
+
+
+def test_download_image_returns_none_on_failure(tmp_path: Any) -> None:
+    d = make_directive(
+        {"repo": "ROCm/HIP", "path": "docs/index.rst"},
+        srcdir=str(tmp_path),
+    )
+    with unittest.mock.patch(
+        "requests.get",
+        side_effect=requests.exceptions.ConnectionError("no net"),
+    ):
+        assert d.download_image("docs/data/img.png", "7.14.0") is None
+
+
+def test_setup_registers_directive_and_config() -> None:
+    from rocm_docs.remote_content import setup
+
+    app = unittest.mock.NonCallableMock()
+    meta = setup(app)
+    app.add_directive.assert_called_once_with(
+        "remote-content", BranchAwareRemoteContent
+    )
+    app.add_config_value.assert_called_once()
+    assert app.add_config_value.call_args.args[0] == CONFIG_DOCS_BASE
+    assert meta["parallel_read_safe"] is True
+    assert meta["parallel_write_safe"] is True


### PR DESCRIPTION
## Motivation

Add rocm_docs.remote_content, a single maintained home for the branch-aware remote-content directive that had been copy-pasted and diverged across ROCm docs repos (ROCm, amd-rocm-programming-guide, and the orher guides — four copies, no two byte-identical). This consolidates the superset of all known copies: doc_ignore/doc_remap, literal and regex replacements, CSV width injection, LaTeX-math fixing, RTD-aware version detection, image download, and the release→default_branch fetch fallback.

The config value follows the library convention (rocm_docs_remote_content_docs_base). The extension is opt-in like rocm_docs.selector (consumers add "rocm_docs.remote_content" to their own extensions list; it is not force-loaded via core.py).
Adds unit tests covering the network-free transforms and the mocked fetch/fallback/image paths, a user-guide page, and declares requests as an explicit dependency.

## Technical Details

- src/rocm_docs/remote_content.py (new) — the canonical BranchAwareRemoteContent directive. setup(app) registers the remote-content directive and the rocm_docs_remote_content_docs_base config value (default https://rocm.docs.amd.com/projects), and returns parallel_read_safe/parallel_write_safe. Network I/O (requests.get) is isolated in fetch_and_parse_content / download_image, and image-path resolution is factored into a pure _resolve_image_path helper so the transform logic is unit-testable. Fully type-hinted to satisfy the repo's strict mypy config.
- tests/test_remote_content.py (new) — 38 tests. The network-free transforms (:doc: conversion, doc_ignore/doc_remap parsing + application, relative-path resolution, replace/replace_re, CSV widths, LaTeX math, get_target_ref/get_current_version across the three RTD detection paths, _resolve_image_path) are exercised directly against a stubbed Sphinx env; the fetch/tag→branch fallback and image download are covered with requests.get mocked.
- docs/user_guide/remote_content.md + docs/sphinx/_toc.yml.in — new user-guide page documenting the directive, every option, and the config value; added to the user-guide TOC.
- pyproject.toml — declares requests>=2.28.0 as an explicit runtime dependency (previously only transitive).
- .wordlist.txt — adds Namespaced and repo for the spellcheck gate.

## Test Plan

- Run the code-style gate: ruff, isort, black, and mypy on src/tests.
- Run the new unit tests plus the full existing suite.
- Build the rocm-docs-core docs and confirm the new user-guide page renders and appears in the TOC.
- Pass the CI markdownlint and spellcheck gates on the new Markdown.
- End-to-end: install the branch into a consumer (amd-rocm-programming-guide) docs venv, swap its conf.py to rocm_docs.remote_content, and build a page that uses .. remote-content::.

## Test Result

  - ruff, isort, black, mypy: all clean on the changed files.
  - pytest: 38 remote_content tests pass; full suite green (95 passed).
  - Docs build: user_guide/remote_content.html renders (option table + config value present) and is listed in the sidebar TOC.
  - markdownlint (MD038) and spellcheck: pass after escaping table-cell pipes and wordlist additions.
  - Consumer build: the migrated programming-guide build inlined remote content from ROCm/ROCm, rewrote :doc: roles to external URLs,
  and downloaded images into _remote_images/ — no regression vs. the vendored copy.
  
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
